### PR TITLE
Fix 're-released' Linx and GRIPSS download URLs and filepaths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN \
   echo 'Retrieving required HMF tools' && \
   wget --quiet --directory-prefix /opt/hmftools/ "${GH_DOWNLOAD_URL_PREFIX}/amber-v3.5/amber-3.5.jar" & \
   wget --quiet --directory-prefix /opt/hmftools/ "${GH_DOWNLOAD_URL_PREFIX}/cobalt-v1.11/cobalt-1.11.jar" & \
-  wget --quiet --directory-prefix /opt/hmftools/ "${GH_DOWNLOAD_URL_PREFIX}/gripss-v2.0/gripss_v2.0.jar" & \
+  wget --quiet --directory-prefix /opt/hmftools/ "${GH_DOWNLOAD_URL_PREFIX}/gripss-v2.0/gripss.jar" & \
   wget --quiet --directory-prefix /opt/hmftools/ "${GH_DOWNLOAD_URL_PREFIX}/purple-v3.2/purple_v3.2.jar" & \
-  wget --quiet --directory-prefix /opt/hmftools/ "${GH_DOWNLOAD_URL_PREFIX}/linx-v1.17/linx_v1.17.jar" & \
+  wget --quiet --directory-prefix /opt/hmftools/ "${GH_DOWNLOAD_URL_PREFIX}/linx-v1.17/linx.jar" & \
   wait
 
 # Install R dependencies for HMF tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,20 +5,20 @@ RUN \
   apt-get install -y \
     cpanminus \
     libgd-dev \
-    libmagick++-dev && \
+    libmagick++-dev \
+    parallel && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
 # Download HMF tools
 ARG GH_DOWNLOAD_URL_PREFIX=https://github.com/hartwigmedical/hmftools/releases/download
 RUN \
-  echo 'Retrieving required HMF tools' && \
-  wget --quiet --directory-prefix /opt/hmftools/ "${GH_DOWNLOAD_URL_PREFIX}/amber-v3.5/amber-3.5.jar" & \
-  wget --quiet --directory-prefix /opt/hmftools/ "${GH_DOWNLOAD_URL_PREFIX}/cobalt-v1.11/cobalt-1.11.jar" & \
-  wget --quiet --directory-prefix /opt/hmftools/ "${GH_DOWNLOAD_URL_PREFIX}/gripss-v2.0/gripss.jar" & \
-  wget --quiet --directory-prefix /opt/hmftools/ "${GH_DOWNLOAD_URL_PREFIX}/purple-v3.2/purple_v3.2.jar" & \
-  wget --quiet --directory-prefix /opt/hmftools/ "${GH_DOWNLOAD_URL_PREFIX}/linx-v1.17/linx.jar" & \
-  wait
+  parallel -j5 --progress wget --quiet --directory-prefix /opt/hmftools/ "${GH_DOWNLOAD_URL_PREFIX}/{}" ::: \
+    amber-v3.5/amber-3.5.jar \
+    cobalt-v1.11/cobalt-1.11.jar \
+    gripss-v2.0/gripss.jar \
+    purple-v3.2/purple_v3.2.jar \
+    linx-v1.17/linx.jar
 
 # Install R dependencies for HMF tools
 # AMBER v3.5

--- a/deployment/assets/run_gpl.py
+++ b/deployment/assets/run_gpl.py
@@ -429,9 +429,9 @@ def get_config_params(config_settings):
         'jar_amber = \'/opt/hmftools/amber-3.5.jar\'',
         'jar_cobalt = \'/opt/hmftools/cobalt-1.11.jar\'',
         'jar_gridss = \'/opt/gridss/gridss-2.13.1-gridss-jar-with-dependencies.jar\'',
-        'jar_gripss = \'/opt/hmftools/gripss_v2.0.jar\'',
+        'jar_gripss = \'/opt/hmftools/gripss.jar\'',
         'jar_purple = \'/opt/hmftools/purple_v3.2.jar\'',
-        'jar_linx = \'/opt/hmftools/linx_v1.17.jar\'',
+        'jar_linx = \'/opt/hmftools/linx.jar\'',
         'path_circos = \'/opt/circos/bin/circos\'',
     ]
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -25,9 +25,9 @@ params {
   jar_amber = '/opt/hmftools/amber-3.5.jar'
   jar_cobalt = '/opt/hmftools/cobalt-1.11.jar'
   jar_gridss = '/opt/gridss/gridss-2.13.1-gridss-jar-with-dependencies.jar'
-  jar_gripss = '/opt/hmftools/gripss-v2.0.jar'
-  jar_linx = '/opt/hmftools/linx_v1.17.jar'
+  jar_gripss = '/opt/hmftools/gripss.jar'
   jar_purple = '/opt/hmftools/purple_v3.2.jar'
+  jar_linx = '/opt/hmftools/linx.jar'
   // Misc paths
   path_circos = '/opt/circos/bin/circos'
 


### PR DESCRIPTION
The `gripss-v2.0` and `linx-v1.17` tags in the [hmftools](https://github.com/hartwigmedical/hmftools/) have been moved to newer commits and download URLs for JAR files in the associated releases were changed. This caused the latest Docker build for the base GRIDSS/PURPLE/Linx image to silently fail - GRIPSS and Linx JAR files were not correctly downloaded nor was any error raised.

This PR fixes:
- download URLs and destination filepaths for GRIPSS 2.0 and Linx 1.17,
- method used to download HMF tools so that errors are captured