### PR TITLE
Fix Docker image build

### DIFF
--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -18,7 +18,12 @@ RUN \
     boto3 \
     nextflow \
     'r-gpgr ==1.3.1' \
-    unzip && \
+    unzip \
+    # NOTE(SW): at the time of 20230306, r-gpgr v1.3.1 requires setting r-cli >=3.4.0,
+    # r-lifecycle >= 1.0.3, and r-rmarkdown ==2.14
+    'r-cli >=3.4.0' \
+    'r-lifecycle >=1.0.3' \
+    'r-rmarkdown ==2.14' && \
   mamba clean --all --force-pkgs-dirs --yes
 
 # Install AWS CLI v2, appears to only be available through direct download


### PR DESCRIPTION
Background

* Several minor changes have been made to the pipeline that are to be deployed to production
  * #25 
  * #26
  * #28 
* Rebuilding Docker images for 0.2.0 and building for new releases has become difficult due to:
  * Drifted Conda dependency solutions the now provide incompatible software versions
  * Conda adjusting software version between install commands; main offender is OpenSSL v1.1.1 to v3
  * LINX 1.20 no longer being available as a JAR; the 1.20 GH release asset has been updated to 1.20_rc1, which doesn't seem to run on previously successful test cases and also reports version as 1.22 at the CLI
* The gridss-purple-linx-nf pipeline and stack are to be replaced in the future by oncoanalyser etc

Solution

* Given these considerations, the AWS `gpl-nf:0.2.1` Docker image will be based from `scwatts/gpl:0.2.0` with required adjustments made
* In the unlikely event that a major or minor release is required, Docker images will be overhauled at that point and appropriately tested

Changes

* Minimal change set to Dockerfiles to allow good build for AWS `gpl-nf:0.2.1` from `scwatts/gpl:0.2.0`