### PR TITLE
Update DRAGEN somatic directory for job submission

### DIFF
--- a/deployment/lambdas/submit_job/lambda_entrypoint.py
+++ b/deployment/lambdas/submit_job/lambda_entrypoint.py
@@ -361,7 +361,7 @@ def get_submission_data(tumor_sample_md, normal_sample_md, subject_id, api_auth)
     tumor_sv_vcf = get_file_path(fr'^.+{tumor_id}.sv.vcf.gz$', file_list)
 
     # Set output directory using tumor BAM path
-    outdir_regex = re.compile(r'^gds://[^/]+/(.+)/wgs_tumor_normal/.+/(L\d+)_(L\d+)_dragen/.+?\.bam$')
+    outdir_regex = re.compile(r'^gds://[^/]+/(.+)/wgs_tumor_normal/.+/(L\d+)_(L\d+)_dragen_somatic/.+?\.bam$')
     if not (re_result := outdir_regex.match(tumor_bam)):
         msg = (
             f'found non-standard input directory for tumor BAM ({tumor_bam}), refusing to guess'

--- a/deployment/lambdas/submit_job/lambda_entrypoint.py
+++ b/deployment/lambdas/submit_job/lambda_entrypoint.py
@@ -361,7 +361,7 @@ def get_submission_data(tumor_sample_md, normal_sample_md, subject_id, api_auth)
     tumor_sv_vcf = get_file_path(fr'^.+{tumor_id}.sv.vcf.gz$', file_list)
 
     # Set output directory using tumor BAM path
-    outdir_regex = re.compile(r'^gds://[^/]+/(.+)/wgs_tumor_normal/.+/(L\d+)_(L\d+)_dragen_somatic/.+?\.bam$')
+    outdir_regex = re.compile(r'^gds://[^/]+/(.+)/wgs_tumor_normal/.+/(L\d+)_(L\d+)_dragen(?:_somatic)?/.+?\.bam$')
     if not (re_result := outdir_regex.match(tumor_bam)):
         msg = (
             f'found non-standard input directory for tumor BAM ({tumor_bam}), refusing to guess'


### PR DESCRIPTION
* Output directory names for DRAGEN runs have been modified in an update to Data Portal orchestration, see [pr#572](https://github.com/umccr/data-portal-apis/pull/572)
* This PR aligns job submission with the above change